### PR TITLE
Update node-sass version in basic package..json

### DIFF
--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -36,7 +36,7 @@
     "grommet-cli": "^5.0.0",
     "jest-cli": "^20.0.4",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.1.1",
+    "node-sass": "^4.9.0",
     "pre-commit": "^1.2.2",
     "react-dev-utils": "^0.4.2",
     "react-test-renderer": "^15.4.1",


### PR DESCRIPTION
Update node-sass version to 4.9.0 since 4.1.1 depended on  a vulnerable version of hoek node module which suffers from a (MAID) vulnerability.  see https://nvd.nist.gov/vuln/detail/CVE-2018-3728 for more information.